### PR TITLE
chore: CI for rust

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,0 +1,123 @@
+name: CI Rust
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  TVM_HOME: /opt/tvm
+  TVM_LIBRARY_PATH: /opt/tvm/lib
+  PYTHONPATH: /home/runner/work/tvm/tvm/python
+  RUST_BACKTRACE: 1
+
+jobs:
+  linux:
+    if: ${{ github.repository == 'todalab/tvm' }}
+    runs-on: Ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install llvm, libncurses5-dev
+        run: |
+           sudo apt-get install -y libtinfo5 llvm
+
+      - name: Cache libtvm
+        id: cache-libtvm
+        uses: actions/cache@v4
+        with:
+          path: /opt/tvm
+          key: ${{ runner.os }}-libtvm-v0.18.0
+
+      - name: Build libtvm, libtvm_runtime
+        if: steps.cache-libtvm.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p build
+          cd build
+          cp ../cmake/config.cmake .
+          echo set\(USE_SORT ON\) >> config.cmake
+          echo set\(USE_RPC ON\) >> config.cmake
+          echo set\(USE_MICRO ON\) >> config.cmake
+          echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
+          echo set\(USE_PROFILER ON\) >> config.cmake
+          echo set\(USE_LLVM ON\) >> config.cmake
+          echo set\(CMAKE_CXX_FLAGS -Werror\) >> config.cmake
+          echo set\(USE_CCACHE OFF\) >> config.cmake
+          echo set\(BACKTRACE_ON_SEGFAULT ON\) >> config.cmake
+          echo set\(USE_UMA OFF\) >> config.cmake
+          echo set\(SUMMARIZE ON\) >> config.cmake
+          echo set\(INSTALL_DEV ON\) >> config.cmake
+
+          cmake .. -DCMAKE_INSTALL_PREFIX=/opt/tvm
+          cmake --build . --config Release
+          mkdir /opt/tvm
+          cmake --install .
+
+          echo set\(BUILD_STATIC_RUNTIME ON\) >> config.cmake
+          cmake .. -DCMAKE_INSTALL_PREFIX=/opt/tvm
+          cmake --build . --config Release
+          cmake --install .
+
+      - run: find $PYTHONPATH
+
+      - name: add TVM PATH
+        run: |
+          echo "/opt/tvm" >> "$GITHUB_PATH"
+          find /opt/tvm
+
+      - run: rustc --version
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - run: pip install numpy decorator psutil typing_extensions pytest
+
+      - name: cargo test
+        run: |
+          cd rust
+          export RUSTFLAGS="-L${TVM_LIBRARY_PATH} ${RUSTFLAGS}"
+          export LD_LIBRARY_PATH="${TVM_LIBRARY_PATH}"
+
+          echo tvm-sys start
+          cargo test -p tvm-sys --verbose
+
+          echo tvm-rt start
+          cargo test -p tvm-rt --verbose
+
+          echo tvm start
+          cargo test -p tvm --verbose
+
+          echo basics start
+          cargo test -p basics --verbose
+
+          echo callback start
+          cargo test -p callback --verbose
+
+          echo tvm-macros start
+          cargo test -p tvm-macros --verbose
+
+          echo compiler-ext start
+          cargo test -p compiler-ext --verbose
+
+          echo tvm-graph-rt start
+          cargo test -p tvm-graph-rt --verbose
+
+          echo test-rt-tvm-basic start
+          cargo test -p test-rt-tvm-basic --verbose
+
+          echo test-rt-tvm-dso start
+          cargo test -p test-rt-tvm-dso --verbose
+
+          echo test-rt-nn start
+          cargo test -p test-rt-nn --verbose
+
+          # echo test-rt-wasm32 start
+          # cargo test -p test-rt-wasm32 --verbose

--- a/rust/compiler-ext/Cargo.toml
+++ b/rust/compiler-ext/Cargo.toml
@@ -27,6 +27,6 @@ crate-type = ["staticlib", "cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tvm = { path = "../tvm", default-features = false, features = ["static-linking"] }
+tvm = { path = "../tvm", default-features = false }
 log = "*"
 env_logger = "*"

--- a/rust/tvm-sys/build.rs
+++ b/rust/tvm-sys/build.rs
@@ -244,6 +244,10 @@ fn main() -> Result<()> {
                 println!("cargo:rustc-link-lib=static={}", library_name);
                 // TODO(@jroesch): move this to tvm-build as library_path?
                 println!(
+                    "cargo:rustc-link-search=native={}/lib",
+                    build_path.display()
+                );
+                println!(
                     "cargo:rustc-link-search=native={}/build",
                     build_path.display()
                 );
@@ -251,6 +255,10 @@ fn main() -> Result<()> {
 
             if cfg!(feature = "dynamic-linking") {
                 println!("cargo:rustc-link-lib=dylib={}", library_name);
+                println!(
+                    "cargo:rustc-link-search=native={}/lib",
+                    build_path.display()
+                );
                 println!(
                     "cargo:rustc-link-search=native={}/build",
                     build_path.display()

--- a/rust/tvm-sys/src/byte_array.rs
+++ b/rust/tvm-sys/src/byte_array.rs
@@ -28,7 +28,7 @@ use crate::{ArgValue, RetValue};
 ///
 /// ```
 /// let v = b"hello";
-/// let barr = tvm_sys::ByteArray::from(&v);
+/// let barr = tvm_sys::ByteArray::from(v);
 /// assert_eq!(barr.len(), v.len());
 /// assert_eq!(barr.data(), &[104u8, 101, 108, 108, 111]);
 /// ```


### PR DESCRIPTION
# 目的

rustモジュールの自動テストを実行するCIを作成し、rustコードの変更に問題がないことを検知可能にする

# 背景

WindowsでRustを経由したランタイムを利用したいため、Windowsでビルドできるようにしたいがコードの変更を行う必要がありそうである。しかし、RustモジュールのCIが実行されておらずテストが現状動作するのかわからない状況であり変更がしづらい。
そのため、まずはLinuxでrustモジュールのCIを実行させ、動作することを確認し、問題があれば修正を行い、Windowsでもビルドを行えるようにする。

# 変更内容など

- libtvm.so libtvm_runtime.so libtvm.a の作成とキャッシュ
  - ビルドに1時間程度かかる。依存プロジェクトでは今後ここでビルドしたバイナリをCIで再利用することで金銭面でも時間面でもコスト低減をはかる
- rustディレクトリないの各自動テストの実行
  - 一部エラーが発生するテストがあったため修正
- 公式のCIはconda環境のダイナミックライブラリをリンクさせてビルドさせているが、llvmやlibstd周りのリンクでrustバイナリのコンパイルや実行時のライブラリ検索を解決するのが難しく、諦めてrunner側のOSで環境を構築している。
  - Conda環境が使えるほうがWindows環境の構築で楽ができる可能性があったがWindows環境は別途なんとかする必要があるだろう
- tvm-sysのビルド時にbinding-genの問題が 一時期のバージョンで起きていた可能性があり、バージョンを上げていたがが現在は解決しているようで、変更を一旦取り除いている。ただ、今後のことを考えるとなるべく最新のもの採用していくことをしていたほうが良いだろう

# 変更内容の本家へのPR方針

必要があれば一部を切り出して本家にPRすることを検討する。そのままPR出せるクオリティで変更するのはコストが高いため。競合しにくく変更することを念頭おきつつも必要があれば、大胆に行う。